### PR TITLE
Helping to get your website unstuck

### DIFF
--- a/source/edition/index.html
+++ b/source/edition/index.html
@@ -2,7 +2,7 @@
 layout: default
 title: Editions
 id: main
-use: editions
+use: [editions]
 ---
 
             <div class="content" id="description">
@@ -12,7 +12,7 @@ use: editions
             </div>
             <div class="content">
                 <ul>
-                    {% for edition in page.editions %}
+                    {% for edition in data.editions %}
                     <li><a href="{{ edition.url }}">{{ edition.date | date("Y/m/d") }} - {{ edition.title }}</a></li>
                     {% endfor %}
                 </ul>


### PR DESCRIPTION
When you `use` a data provider, Sculpin currently expects you to `use` an array.

This should maybe change to be more flexible (string or array). Also, data providers are provided via `data` and not `page`.

This is a failure on the documentation and in the examples as I don't currently have anything using a data provider directly and always by way of the pagination generator (I think?) so it is understandable that this would trip someone up.

Thanks for trying to work through it. :)
